### PR TITLE
DFI-1896 Add scenarios for grs/bv journey creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,19 +99,20 @@ Simulates the GRS/BV journey data retrieval endpoint.
 
 This can be triggered directly with calls, or by using the create journey endpoint, using one of the following journeyIds as credId.
 
-| Scenario                   | `journeyId` or `credId`    | Response           |
-|----------------------------|---------------------------| ------------------ |
-| Success                    | `success`                 | `200 OK`           |
-| Identifiers Mismatch       | `identifiers-fail`        | `200 OK`           |
-| Business Verification Fail | `bv-fail`                 | `200 OK`           |
-| BV Not Called              | `bv-not-called`           | `200 OK`           |
-| CT Enrolled                | `bv-ct-enrolled`          | `200 OK`           |
-| Registration Failed        | `registration-failed`     | `200 OK`           |
-| Registration Not Called    | `registration-not-called` | `200 OK`           |
-| CT UTR Absent              | `ct-utr-absent`           | `200 OK`           |
-| Not Found                  | `grs-data-not-found`      | `404 Not Found`    |
-| Unauthorized               | auth fails                | `401 Unauthorized` |
-| Success (default)          | any other value           | `200 OK`           |
+| Scenario                   | `journeyId` or `credId`              | Response           |
+|----------------------------|--------------------------------------|--------------------|
+| Success                    | `grs-retrieval-success`              | `200 OK`           |
+| Identifiers Mismatch       | `grs-retrieval-identifiers-fail`     | `200 OK`           |
+| Business Verification Fail | `grs-retrieval-bv-fail`              | `200 OK`           |
+| BV Not Called              | `grs-retrieval-bv-not-called`        | `200 OK`           |
+| CT Enrolled                | `grs-retrieval-bv-ct-enrolled`       | `200 OK`           |
+| Registration Failed        | `grs-retrieval-registration-failed`  | `200 OK`           |
+| Registration Not Called    | `grs-retrieval-registration-not-called` | `200 OK`        |
+| CT UTR Absent              | `grs-retrieval-ct-utr-absent`        | `200 OK`           |
+| Not Found                  | `grs-retrieval-data-not-found`       | `404 Not Found`    |
+| Unauthorized (stubbed)     | `grs-retrieval-unauthorised`         | `401 Unauthorized` |
+| Unauthorized (real)        | auth fails                           | `401 Unauthorized` |
+| Success (default)          | any other value                      | `200 OK`           |
 
 ### PUT /tax-enrolments/subscriptions/:subscriptionId/subscriber
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,33 @@ sbt scalafmtSbt
 # formats just the main source files (excludes test and configuration files)
 sbt scalafmt
 ```
+
+## Endpoints
+### GET /journey/:journeyId
+Simulates the GRS/BV journey data retrieval endpoint.
+
+| Scenario                   | `journeyId`               | Response           |
+|----------------------------| ------------------------- | ------------------ |
+| Success                    | `success`                 | `200 OK`           |
+| Identifiers Mismatch       | `identifiers-fail`        | `200 OK`           |
+| Business Verification Fail | `bv-fail`                 | `200 OK`           |
+| BV Not Called              | `bv-not-called`           | `200 OK`           |
+| CT Enrolled                | `bv-ct-enrolled`          | `200 OK`           |
+| Registration Failed        | `registration-failed`     | `200 OK`           |
+| Registration Not Called    | `registration-not-called` | `200 OK`           |
+| CT UTR Absent              | `ct-utr-absent`           | `200 OK`           |
+| Not Found                  | `grs-data-not-found`      | `404 Not Found`    |
+| Unauthorized               | auth fails                | `401 Unauthorized` |
+| Success (default)          | any other value           | `200 OK`           |
+
+### PUT /tax-enrolments/subscriptions/:subscriptionId/subscriber
+
+| Scenario     | `credId`                             | Response           |
+| ------------ | ------------------------------------ | ------------------ |
+| Success      | anything except specific test values | `204 No Content`   |
+| Bad Request  | `tax-enrolment-bad-request`          | `400 Bad Request`  |
+| Unauthorized | auth fails or no credentials         | `401 Unauthorized` |
+
 ### Further documentation
 
 You can view further information regarding this service via our [service guide](#).
@@ -79,12 +106,5 @@ This code is open source software licensed under the [Apache 2.0 License]("http:
 
 ### Endpoints
 
-#### PUT /tax-enrolments/subscriptions/:subscriptionId/subscriber
-
-| Scenario     | `credId`                             | Response           |
-| ------------ | ------------------------------------ | ------------------ |
-| Success      | anything except specific test values | `204 No Content`   |
-| Bad Request  | `tax-enrolment-bad-request`          | `400 Bad Request`  |
-| Unauthorized | auth fails or no credentials         | `401 Unauthorized` |
 
 

--- a/README.md
+++ b/README.md
@@ -71,25 +71,27 @@ sbt scalafmt
 
 ## Endpoints
 
+## Endpoints
+
 ### POST /incorporated-entity-identification/api/limited-company-journey
 Simulates the GRS create limited company journey endpoint.
 
-The response is driven by the `credId` returned from Auth (derived from the bearer token in tests).
+The response is driven by the `credId` returned from Auth.
 
-| Scenario                | `credId`                          | Response                      |
-|------------------------|-----------------------------------|-------------------------------|
-| Unauthorized           | `grs-create-journey-unauthorised` | `401 Unauthorized`            |
-| Upstream Error         | `grs-create-journey-upstream-error` | `500 Internal Server Error` |
-| Invalid JSON (stubbed) | `grs-create-journey-invalid-json` | `400 Bad Request`             |
-| Invalid URLs (stubbed) | `grs-create-journey-invalid-urls` | `400 Bad Request`             |
-| Success                | `grs-create-journey-success`      | `201 Created`                 |
-| Success (default)      | any other value                   | `201 Created`                 |
+| Scenario                | `credId`                            | Response                      |
+|-------------------------|-------------------------------------|-------------------------------|
+| Unauthorized            | `grs-create-journey-unauthorised`   | `401 Unauthorized`            |
+| Upstream Error          | `grs-create-journey-upstream-error` | `500 Internal Server Error`   |
+| Invalid JSON (stubbed)  | `grs-create-journey-invalid-json`   | `400 Bad Request`             |
+| Invalid URLs (stubbed)  | `grs-create-journey-invalid-urls`   | `400 Bad Request`             |
+| Success                 | `grs-create-journey-success`        | `201 Created`                 |
+| Success (default)       | any other value                     | `201 Created`                 |
 
 For successful responses, the body will be:
 
 ```json
 {
-  "journeyStartUrl": "<disa-reg-frontend>/incorporated-identity-callback?journeyId=<credId>"
+  "journeyStartUrl": "/obligations/enrolment/isa/incorporated-identity-callback?journeyId=<credId>"
 }
 ```
 Where `<credId>` is reused as the journeyId for subsequent calls to the journey data retrieval endpoint (see below).
@@ -97,22 +99,19 @@ Where `<credId>` is reused as the journeyId for subsequent calls to the journey 
 ### GET /journey/:journeyId
 Simulates the GRS/BV journey data retrieval endpoint.
 
-This can be triggered directly with calls, or by using the create journey endpoint, using one of the following journeyIds as credId.
+This can be triggered directly with calls, or by using the create journey endpoint with one of the following retrieval journey IDs as the Auth `credId`.
 
-| Scenario                   | `journeyId` or `credId`              | Response           |
-|----------------------------|--------------------------------------|--------------------|
-| Success                    | `grs-retrieval-success`              | `200 OK`           |
-| Identifiers Mismatch       | `grs-retrieval-identifiers-fail`     | `200 OK`           |
-| Business Verification Fail | `grs-retrieval-bv-fail`              | `200 OK`           |
-| BV Not Called              | `grs-retrieval-bv-not-called`        | `200 OK`           |
-| CT Enrolled                | `grs-retrieval-bv-ct-enrolled`       | `200 OK`           |
-| Registration Failed        | `grs-retrieval-registration-failed`  | `200 OK`           |
-| Registration Not Called    | `grs-retrieval-registration-not-called` | `200 OK`        |
-| CT UTR Absent              | `grs-retrieval-ct-utr-absent`        | `200 OK`           |
-| Not Found                  | `grs-retrieval-data-not-found`       | `404 Not Found`    |
-| Unauthorized (stubbed)     | `grs-retrieval-unauthorised`         | `401 Unauthorized` |
-| Unauthorized (real)        | auth fails                           | `401 Unauthorized` |
-| Success (default)          | any other value                      | `200 OK`           |
+| Scenario                   | `journeyId` or `credId`             | Response           | Description                                                                 |
+|----------------------------|-------------------------------------|--------------------|-----------------------------------------------------------------------------|
+| Success                    | `grs-retrieval-success`             | `200 OK`           | Typical success case with user going through GRS and BV                     |
+| Success (CT Enrolled)      | `grs-retrieval-success-ct-enrolled` | `200 OK`           | Success case for users with IR-CT enrolment, fast-tracked through BV        |
+| Business Verification Fail | `grs-retrieval-bv-fail`             | `200 OK`           | Failure in BV journey resulting in lockout                                  |
+| Registration Failed        | `grs-retrieval-registration-failed` | `200 OK`           | Successful verification but failure to register user with ETMP              |
+| Absent UTR                 | `grs-retrieval-absent-utr`          | `200 OK`           | Edge case that can occur with Registered Societies                          |
+| Not Found                  | `grs-retrieval-data-not-found`      | `404 Not Found`    | No journey data found for the given ID                                      |
+| Unauthorized (stubbed)     | `grs-retrieval-unauthorised`        | `401 Unauthorized` | Explicit stubbed unauthorized response                                      |
+| Unauthorized (real)        | auth fails                          | `401 Unauthorized` | Real authorization failure (e.g. missing or invalid credentials)            |
+| Success (default)          | any other value                     | `200 OK`           | Defaults to typical success response                                        |
 
 ### PUT /tax-enrolments/subscriptions/:subscriptionId/subscriber
 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,37 @@ sbt scalafmt
 ```
 
 ## Endpoints
+
+### POST /incorporated-entity-identification/api/limited-company-journey
+Simulates the GRS create limited company journey endpoint.
+
+The response is driven by the `credId` returned from Auth (derived from the bearer token in tests).
+
+| Scenario                | `credId`                          | Response                      |
+|------------------------|-----------------------------------|-------------------------------|
+| Unauthorized           | `grs-create-journey-unauthorised` | `401 Unauthorized`            |
+| Upstream Error         | `grs-create-journey-upstream-error` | `500 Internal Server Error` |
+| Invalid JSON (stubbed) | `grs-create-journey-invalid-json` | `400 Bad Request`             |
+| Invalid URLs (stubbed) | `grs-create-journey-invalid-urls` | `400 Bad Request`             |
+| Success                | `grs-create-journey-success`      | `201 Created`                 |
+| Success (default)      | any other value                   | `201 Created`                 |
+
+For successful responses, the body will be:
+
+```json
+{
+  "journeyStartUrl": "<disa-reg-frontend>/incorporated-identity-callback?journeyId=<credId>"
+}
+```
+Where `<credId>` is reused as the journeyId for subsequent calls to the journey data retrieval endpoint (see below).
+
 ### GET /journey/:journeyId
 Simulates the GRS/BV journey data retrieval endpoint.
 
-| Scenario                   | `journeyId`               | Response           |
-|----------------------------| ------------------------- | ------------------ |
+This can be triggered directly with calls, or by using the create journey endpoint, using one of the following journeyIds as credId.
+
+| Scenario                   | `journeyId` or `credId`    | Response           |
+|----------------------------|---------------------------| ------------------ |
 | Success                    | `success`                 | `200 OK`           |
 | Identifiers Mismatch       | `identifiers-fail`        | `200 OK`           |
 | Business Verification Fail | `bv-fail`                 | `200 OK`           |
@@ -102,9 +128,3 @@ You can view further information regarding this service via our [service guide](
 ### License
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").
-
-
-### Endpoints
-
-
-

--- a/app/uk/gov/hmrc/disaregistrationstubs/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/disaregistrationstubs/config/AppConfig.scala
@@ -18,9 +18,14 @@ package uk.gov.hmrc.disaregistrationstubs.config
 
 import javax.inject.{Inject, Singleton}
 import play.api.Configuration
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 @Singleton
-class AppConfig @Inject() (config: Configuration) {
+class AppConfig @Inject() (servicesConfig: ServicesConfig, config: Configuration) {
 
   val appName: String = config.get[String]("appName")
+
+  val selfHost: String = config.get("host")
+
+  val disaRegFrontendUrl: String = servicesConfig.baseUrl("disa-registration-frontend")
 }

--- a/app/uk/gov/hmrc/disaregistrationstubs/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/disaregistrationstubs/config/AppConfig.scala
@@ -28,6 +28,6 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig, config: Configuration
   val appName: String = config.get[String]("appName")
 
   val disaRegFrontendUrl: String = servicesConfig.baseUrl("disa-registration-frontend")
-  
+
   val allowedHosts: Set[String] = config.underlying.getStringList("microservice.hosts.allowList").asScala.toSet
 }

--- a/app/uk/gov/hmrc/disaregistrationstubs/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/disaregistrationstubs/config/AppConfig.scala
@@ -20,12 +20,14 @@ import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
+import scala.jdk.CollectionConverters._
+
 @Singleton
 class AppConfig @Inject() (servicesConfig: ServicesConfig, config: Configuration) {
 
   val appName: String = config.get[String]("appName")
 
-  val selfHost: String = config.get("host")
-
   val disaRegFrontendUrl: String = servicesConfig.baseUrl("disa-registration-frontend")
+  
+  val allowedHosts: Set[String] = config.underlying.getStringList("microservice.hosts.allowList").asScala.toSet
 }

--- a/app/uk/gov/hmrc/disaregistrationstubs/controllers/GrsController.scala
+++ b/app/uk/gov/hmrc/disaregistrationstubs/controllers/GrsController.scala
@@ -24,6 +24,7 @@ import uk.gov.hmrc.auth.core.{AuthConnector, AuthorisationException, AuthorisedF
 import uk.gov.hmrc.disaregistrationstubs.config.AppConfig
 import uk.gov.hmrc.disaregistrationstubs.models.GrsCreateJourneyRequest
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import uk.gov.hmrc.play.bootstrap.binders.{AbsoluteWithHostnameFromAllowlist, OnlyRelative}
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -62,7 +63,7 @@ class GrsController @Inject() (
                   Created(
                     Json.obj(
                       "journeyStartUrl" ->
-                        s"${appConfig.disaRegFrontendUrl}/incorporated-identity-callback?journeyId=$credId"
+                        s"/obligations/enrolment/isa/incorporated-identity-callback?journeyId=$credId"
                     )
                   )
               }
@@ -234,6 +235,5 @@ class GrsController @Inject() (
     ).exists(url => !isValidUrl(url))
 
   private def isValidUrl(url: String): Boolean =
-    if (appConfig.selfHost.isBlank) url.startsWith("/")
-    else url.startsWith("/") || url.startsWith("http://localhost")
+    OnlyRelative.applies(url) || AbsoluteWithHostnameFromAllowlist.apply(appConfig.allowedHosts).applies(url)
 }

--- a/app/uk/gov/hmrc/disaregistrationstubs/controllers/GrsController.scala
+++ b/app/uk/gov/hmrc/disaregistrationstubs/controllers/GrsController.scala
@@ -77,7 +77,10 @@ class GrsController @Inject() (
 
       val response = journeyId match {
 
-        case "success" =>
+        case "grs-retrieval-unauthorised" =>
+          Unauthorized
+
+        case "grs-retrieval-success" =>
           Ok(
             grsJson(
               identifiersMatch = true,
@@ -87,7 +90,7 @@ class GrsController @Inject() (
             )
           )
 
-        case "identifiers-fail" =>
+        case "grs-retrieval-identifiers-fail" =>
           Ok(
             grsJson(
               identifiersMatch = false,
@@ -96,7 +99,7 @@ class GrsController @Inject() (
             )
           )
 
-        case "bv-fail" =>
+        case "grs-retrieval-bv-fail" =>
           Ok(
             grsJson(
               identifiersMatch = true,
@@ -106,7 +109,7 @@ class GrsController @Inject() (
             )
           )
 
-        case "bv-not-called" =>
+        case "grs-retrieval-bv-not-called" =>
           Ok(
             grsJson(
               identifiersMatch = true,
@@ -116,7 +119,7 @@ class GrsController @Inject() (
             )
           )
 
-        case "bv-ct-enrolled" =>
+        case "grs-retrieval-bv-ct-enrolled" =>
           Ok(
             grsJson(
               identifiersMatch = true,
@@ -126,7 +129,7 @@ class GrsController @Inject() (
             )
           )
 
-        case "registration-failed" =>
+        case "grs-retrieval-registration-failed" =>
           Ok(
             grsJson(
               identifiersMatch = true,
@@ -135,7 +138,7 @@ class GrsController @Inject() (
             )
           )
 
-        case "registration-not-called" =>
+        case "grs-retrieval-registration-not-called" =>
           Ok(
             grsJson(
               identifiersMatch = true,
@@ -144,7 +147,7 @@ class GrsController @Inject() (
             )
           )
 
-        case "ct-utr-absent" =>
+        case "grs-retrieval-ct-utr-absent" =>
           Ok(
             grsJson(
               identifiersMatch = true,
@@ -155,8 +158,10 @@ class GrsController @Inject() (
             )
           )
 
-        case "grs-data-not-found" => NotFound
-        case _                    =>
+        case "grs-retrieval-data-not-found" =>
+          NotFound
+
+        case _ =>
           Ok(
             grsJson(
               identifiersMatch = true,
@@ -168,10 +173,9 @@ class GrsController @Inject() (
       }
 
       Future.successful(response)
+    }.recover { case _: AuthorisationException =>
+      Unauthorized
     }
-      .recover { case _: AuthorisationException =>
-        Unauthorized
-      }
   }
 
   private def grsJson(

--- a/app/uk/gov/hmrc/disaregistrationstubs/controllers/GrsController.scala
+++ b/app/uk/gov/hmrc/disaregistrationstubs/controllers/GrsController.scala
@@ -18,18 +18,59 @@ package uk.gov.hmrc.disaregistrationstubs.controllers
 
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.auth.core.retrieve.Credentials
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.credentials
 import uk.gov.hmrc.auth.core.{AuthConnector, AuthorisationException, AuthorisedFunctions}
+import uk.gov.hmrc.disaregistrationstubs.config.AppConfig
+import uk.gov.hmrc.disaregistrationstubs.models.GrsCreateJourneyRequest
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
+@Singleton
 class GrsController @Inject() (
   cc: ControllerComponents,
-  val authConnector: AuthConnector
+  val authConnector: AuthConnector,
+  appConfig: AppConfig
 )(implicit ec: ExecutionContext)
     extends BackendController(cc)
     with AuthorisedFunctions {
+
+  def createLimitedCompanyJourney(): Action[GrsCreateJourneyRequest] =
+    Action(parse.json[GrsCreateJourneyRequest]).async { implicit request =>
+      authorised()
+        .retrieve(credentials) { creds =>
+          val response = creds match {
+            case None                         => InternalServerError("Internal ID could not be retrieved from Auth")
+            case Some(Credentials(credId, _)) =>
+              credId match {
+                case "grs-create-journey-unauthorised"   => Unauthorized
+                case "grs-create-journey-upstream-error" => InternalServerError
+                case "grs-create-journey-invalid-json"   =>
+                  BadRequest(
+                    Json.obj(
+                      "code"    -> "INVALID_JSON",
+                      "message" -> "Request body is invalid"
+                    )
+                  )
+                case "grs-create-journey-invalid-urls"   =>
+                  BadRequest(Json.toJson("JourneyConfig contained non-relative urls"))
+                case _ if hasInvalidUrls(request.body)   =>
+                  BadRequest(Json.toJson("JourneyConfig contained non-relative urls"))
+                case "grs-create-journey-success" | _    =>
+                  Created(
+                    Json.obj(
+                      "journeyStartUrl" ->
+                        s"${appConfig.disaRegFrontendUrl}/incorporated-identity-callback?journeyId=$credId"
+                    )
+                  )
+              }
+          }
+          Future.successful(response)
+        }
+        .recover { case _: AuthorisationException => Unauthorized }
+    }
 
   def retrieveJourneyData(journeyId: String): Action[AnyContent] = Action.async { implicit request =>
     authorised() {
@@ -180,4 +221,15 @@ class GrsController @Inject() (
       "postal_code"    -> "ZX719AD"
     )
   )
+
+  private def hasInvalidUrls(request: GrsCreateJourneyRequest): Boolean =
+    Seq(
+      request.continueUrl,
+      request.signOutUrl,
+      request.accessibilityUrl
+    ).exists(url => !isValidUrl(url))
+
+  private def isValidUrl(url: String): Boolean =
+    if (appConfig.selfHost.isBlank) url.startsWith("/")
+    else url.startsWith("/") || url.startsWith("http://localhost")
 }

--- a/app/uk/gov/hmrc/disaregistrationstubs/controllers/GrsController.scala
+++ b/app/uk/gov/hmrc/disaregistrationstubs/controllers/GrsController.scala
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.disaregistrationstubs.controllers
+
+import play.api.libs.json.{JsObject, Json}
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.auth.core.{AuthConnector, AuthorisationException, AuthorisedFunctions}
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class GrsController @Inject() (
+  cc: ControllerComponents,
+  val authConnector: AuthConnector
+)(implicit ec: ExecutionContext)
+    extends BackendController(cc)
+    with AuthorisedFunctions {
+
+  def retrieveJourneyData(journeyId: String): Action[AnyContent] = Action.async { implicit request =>
+    authorised() {
+
+      val response = journeyId match {
+
+        case "success" =>
+          Ok(
+            grsJson(
+              identifiersMatch = true,
+              bvStatus = Some("PASS"),
+              registrationStatus = "REGISTERED",
+              bpId = Some("111111")
+            )
+          )
+
+        case "identifiers-fail" =>
+          Ok(
+            grsJson(
+              identifiersMatch = false,
+              bvStatus = Some("UNCHALLENGED"),
+              registrationStatus = "REGISTRATION_FAILED"
+            )
+          )
+
+        case "bv-fail" =>
+          Ok(
+            grsJson(
+              identifiersMatch = true,
+              bvStatus = Some("FAIL"),
+              registrationStatus = "REGISTERED",
+              bpId = Some("111111")
+            )
+          )
+
+        case "bv-not-called" =>
+          Ok(
+            grsJson(
+              identifiersMatch = true,
+              bvStatus = Some("UNCHALLENGED"),
+              registrationStatus = "REGISTERED",
+              bpId = Some("111111")
+            )
+          )
+
+        case "bv-ct-enrolled" =>
+          Ok(
+            grsJson(
+              identifiersMatch = true,
+              bvStatus = Some("CT_ENROLLED"),
+              registrationStatus = "REGISTERED",
+              bpId = Some("111111")
+            )
+          )
+
+        case "registration-failed" =>
+          Ok(
+            grsJson(
+              identifiersMatch = true,
+              bvStatus = Some("UNCHALLENGED"),
+              registrationStatus = "REGISTRATION_FAILED"
+            )
+          )
+
+        case "registration-not-called" =>
+          Ok(
+            grsJson(
+              identifiersMatch = true,
+              bvStatus = None,
+              registrationStatus = "REGISTRATION_NOT_CALLED"
+            )
+          )
+
+        case "ct-utr-absent" =>
+          Ok(
+            grsJson(
+              identifiersMatch = true,
+              bvStatus = Some("FAIL"),
+              registrationStatus = "REGISTERED",
+              bpId = Some("111111"),
+              includeCtutr = false
+            )
+          )
+
+        case "grs-data-not-found" => NotFound
+        case _                    =>
+          Ok(
+            grsJson(
+              identifiersMatch = true,
+              bvStatus = Some("PASS"),
+              registrationStatus = "REGISTERED",
+              bpId = Some("111111")
+            )
+          )
+      }
+
+      Future.successful(response)
+    }
+      .recover { case _: AuthorisationException =>
+        Unauthorized
+      }
+  }
+
+  private def grsJson(
+    identifiersMatch: Boolean,
+    bvStatus: Option[String],
+    registrationStatus: String,
+    bpId: Option[String] = None,
+    includeCtutr: Boolean = true
+  ): JsObject = {
+
+    val base =
+      Json.obj(
+        "companyProfile"   -> companyProfileJson,
+        "identifiersMatch" -> identifiersMatch,
+        "registration"     -> (
+          Json.obj("registrationStatus" -> registrationStatus) ++
+            bpId.map(id => Json.obj("registeredBusinessPartnerId" -> id)).getOrElse(Json.obj())
+        )
+      )
+
+    val withBv =
+      bvStatus
+        .map(status =>
+          base ++ Json.obj(
+            "businessVerification" -> Json.obj(
+              "verificationStatus" -> status
+            )
+          )
+        )
+        .getOrElse(base)
+
+    val withCtutr =
+      if (includeCtutr) withBv ++ Json.obj("ctutr" -> "1234567890")
+      else withBv
+
+    withCtutr
+  }
+
+  private val companyProfileJson: JsObject = Json.obj(
+    "companyName"            -> "Widgets Ltd",
+    "companyNumber"          -> "12345678",
+    "dateOfIncorporation"    -> "2020-01-01",
+    "unsanitisedCHROAddress" -> Json.obj(
+      "address_line_1" -> "1 Street",
+      "address_line_2" -> "Town",
+      "locality"       -> "County",
+      "postal_code"    -> "ZX719AD"
+    )
+  )
+}

--- a/app/uk/gov/hmrc/disaregistrationstubs/controllers/GrsController.scala
+++ b/app/uk/gov/hmrc/disaregistrationstubs/controllers/GrsController.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.disaregistrationstubs.controllers
 
+import play.api.Logging
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.auth.core.retrieve.Credentials
@@ -36,30 +37,47 @@ class GrsController @Inject() (
   appConfig: AppConfig
 )(implicit ec: ExecutionContext)
     extends BackendController(cc)
-    with AuthorisedFunctions {
+    with AuthorisedFunctions
+    with Logging {
 
   def createLimitedCompanyJourney(): Action[GrsCreateJourneyRequest] =
     Action(parse.json[GrsCreateJourneyRequest]).async { implicit request =>
       authorised()
         .retrieve(credentials) { creds =>
           val response = creds match {
-            case None                         => InternalServerError("Internal ID could not be retrieved from Auth")
+            case None =>
+              logger.warn("Credentials could not be retrieved from Auth when creating GRS journey")
+              InternalServerError("Internal ID could not be retrieved from Auth")
+
             case Some(Credentials(credId, _)) =>
               credId match {
-                case "grs-create-journey-unauthorised"   => Unauthorized
-                case "grs-create-journey-upstream-error" => InternalServerError
-                case "grs-create-journey-invalid-json"   =>
+                case "grs-create-journey-unauthorised" =>
+                  logger.info("Returning stubbed unauthorized response for create GRS journey")
+                  Unauthorized
+
+                case "grs-create-journey-upstream-error" =>
+                  logger.info("Returning stubbed upstream error response for create GRS journey")
+                  InternalServerError
+
+                case "grs-create-journey-invalid-json" =>
+                  logger.info("Returning stubbed invalid JSON response for create GRS journey")
                   BadRequest(
                     Json.obj(
                       "code"    -> "INVALID_JSON",
                       "message" -> "Request body is invalid"
                     )
                   )
-                case "grs-create-journey-invalid-urls"   =>
+
+                case "grs-create-journey-invalid-urls" =>
+                  logger.info("Returning stubbed invalid URLs response for create GRS journey")
                   BadRequest(Json.toJson("JourneyConfig contained non-relative urls"))
-                case _ if hasInvalidUrls(request.body)   =>
+
+                case _ if hasInvalidUrls(request.body) =>
+                  logger.warn(s"Create GRS journey request contained invalid URLs for credId: $credId")
                   BadRequest(Json.toJson("JourneyConfig contained non-relative urls"))
-                case "grs-create-journey-success" | _    =>
+
+                case "grs-create-journey-success" | _ =>
+                  logger.info(s"Returning created GRS journey response for credId: $credId")
                   Created(
                     Json.obj(
                       "journeyStartUrl" ->
@@ -70,7 +88,10 @@ class GrsController @Inject() (
           }
           Future.successful(response)
         }
-        .recover { case _: AuthorisationException => Unauthorized }
+        .recover { case _: AuthorisationException =>
+          logger.warn("Authorisation failed when creating GRS journey")
+          Unauthorized
+        }
     }
 
   def retrieveJourneyData(journeyId: String): Action[AnyContent] = Action.async { implicit request =>
@@ -79,9 +100,11 @@ class GrsController @Inject() (
       val response = journeyId match {
 
         case "grs-retrieval-unauthorised" =>
+          logger.info("Returning stubbed unauthorized response for GRS journey data retrieval")
           Unauthorized
 
         case "grs-retrieval-success" =>
+          logger.info("Returning GRS retrieval success scenario")
           Ok(
             grsJson(
               identifiersMatch = true,
@@ -91,36 +114,8 @@ class GrsController @Inject() (
             )
           )
 
-        case "grs-retrieval-identifiers-fail" =>
-          Ok(
-            grsJson(
-              identifiersMatch = false,
-              bvStatus = Some("UNCHALLENGED"),
-              registrationStatus = "REGISTRATION_FAILED"
-            )
-          )
-
-        case "grs-retrieval-bv-fail" =>
-          Ok(
-            grsJson(
-              identifiersMatch = true,
-              bvStatus = Some("FAIL"),
-              registrationStatus = "REGISTERED",
-              bpId = Some("111111")
-            )
-          )
-
-        case "grs-retrieval-bv-not-called" =>
-          Ok(
-            grsJson(
-              identifiersMatch = true,
-              bvStatus = Some("UNCHALLENGED"),
-              registrationStatus = "REGISTERED",
-              bpId = Some("111111")
-            )
-          )
-
-        case "grs-retrieval-bv-ct-enrolled" =>
+        case "grs-retrieval-success-ct-enrolled" =>
+          logger.info("Returning GRS retrieval CT enrolled success scenario")
           Ok(
             grsJson(
               identifiersMatch = true,
@@ -130,39 +125,43 @@ class GrsController @Inject() (
             )
           )
 
-        case "grs-retrieval-registration-failed" =>
-          Ok(
-            grsJson(
-              identifiersMatch = true,
-              bvStatus = Some("UNCHALLENGED"),
-              registrationStatus = "REGISTRATION_FAILED"
-            )
-          )
-
-        case "grs-retrieval-registration-not-called" =>
-          Ok(
-            grsJson(
-              identifiersMatch = true,
-              bvStatus = None,
-              registrationStatus = "REGISTRATION_NOT_CALLED"
-            )
-          )
-
-        case "grs-retrieval-ct-utr-absent" =>
+        case "grs-retrieval-bv-fail" =>
+          logger.info("Returning GRS retrieval business verification fail scenario")
           Ok(
             grsJson(
               identifiersMatch = true,
               bvStatus = Some("FAIL"),
-              registrationStatus = "REGISTERED",
-              bpId = Some("111111"),
-              includeCtutr = false
+              registrationStatus = "REGISTRATION_NOT_CALLED",
+              bpId = None
+            )
+          )
+
+        case "grs-retrieval-registration-failed" =>
+          logger.info("Returning GRS retrieval registration failed scenario")
+          Ok(
+            grsJson(
+              identifiersMatch = true,
+              bvStatus = Some("PASS"),
+              registrationStatus = "REGISTRATION_FAILED"
+            )
+          )
+
+        case "grs-retrieval-absent-utr" =>
+          logger.info("Returning GRS retrieval absent UTR scenario")
+          Ok(
+            grsJson(
+              identifiersMatch = false,
+              bvStatus = Some("UNCHALLENGED"),
+              registrationStatus = "REGISTRATION_NOT_CALLED"
             )
           )
 
         case "grs-retrieval-data-not-found" =>
+          logger.info("Returning GRS retrieval data not found scenario")
           NotFound
 
         case _ =>
+          logger.info(s"Returning default GRS retrieval success scenario for journeyId: $journeyId")
           Ok(
             grsJson(
               identifiersMatch = true,
@@ -175,6 +174,7 @@ class GrsController @Inject() (
 
       Future.successful(response)
     }.recover { case _: AuthorisationException =>
+      logger.warn(s"Authorisation failed when retrieving GRS journey data for journeyId: $journeyId")
       Unauthorized
     }
   }

--- a/app/uk/gov/hmrc/disaregistrationstubs/models/GrsCreateJourneyRequest.scala
+++ b/app/uk/gov/hmrc/disaregistrationstubs/models/GrsCreateJourneyRequest.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.disaregistrationstubs.models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class GrsCreateJourneyRequest(
+  continueUrl: String,
+  businessVerificationCheck: Boolean,
+  deskProServiceId: String,
+  signOutUrl: String,
+  regime: String,
+  accessibilityUrl: String,
+  labels: Option[Labels]
+)
+
+object GrsCreateJourneyRequest {
+  implicit val format: OFormat[GrsCreateJourneyRequest] = Json.format[GrsCreateJourneyRequest]
+}
+
+case class ServiceLabel(optServiceName: String)
+
+object ServiceLabel {
+  implicit val format: OFormat[ServiceLabel] = Json.format[ServiceLabel]
+}
+
+case class Labels(
+  cy: Option[ServiceLabel] = None,
+  en: Option[ServiceLabel]
+)
+object Labels {
+  implicit val format: OFormat[Labels] = Json.format[Labels]
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -4,4 +4,8 @@ PUT     /tax-enrolments/subscriptions/:subscriptionId/subscriber    uk.gov.hmrc.
 
 POST    /etmp/enrolment/submission                                  uk.gov.hmrc.disaregistrationstubs.controllers.EtmpController.submitEnrolment()
 
+
+## GRS/BV Stubs
+
+POST    /incorporated-entity-identification/api/limited-company-journey  uk.gov.hmrc.disaregistrationstubs.controllers.GrsController.createLimitedCompanyJourney()
 GET     /journey/:journeyId                                 uk.gov.hmrc.disaregistrationstubs.controllers.GrsController.retrieveJourneyData(journeyId: String)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,5 +1,7 @@
 # microservice specific routes
 
+PUT     /tax-enrolments/subscriptions/:subscriptionId/subscriber    uk.gov.hmrc.disaregistrationstubs.controllers.TaxEnrolmentController.subscribe(subscriptionId: String)
+
 POST    /etmp/enrolment/submission                                  uk.gov.hmrc.disaregistrationstubs.controllers.EtmpController.submitEnrolment()
 
-PUT     /tax-enrolments/subscriptions/:subscriptionId/subscriber    uk.gov.hmrc.disaregistrationstubs.controllers.TaxEnrolmentController.subscribe(subscriptionId: String)
+GET     /journey/:journeyId                                 uk.gov.hmrc.disaregistrationstubs.controllers.GrsController.retrieveJourneyData(journeyId: String)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -8,4 +8,4 @@ POST    /etmp/enrolment/submission                                  uk.gov.hmrc.
 ## GRS/BV Stubs
 
 POST    /incorporated-entity-identification/api/limited-company-journey  uk.gov.hmrc.disaregistrationstubs.controllers.GrsController.createLimitedCompanyJourney()
-GET     /journey/:journeyId                                 uk.gov.hmrc.disaregistrationstubs.controllers.GrsController.retrieveJourneyData(journeyId: String)
+GET     /incorporated-entity-identification/api/journey/:journeyId       uk.gov.hmrc.disaregistrationstubs.controllers.GrsController.retrieveJourneyData(journeyId: String)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -60,9 +60,9 @@ mongodb {
   uri = "mongodb://localhost:27017/disa-registration-stubs"
 }
 
-host = "http://localhost:1203"
-
 microservice {
+  hosts.allowList = ["localhost"]
+
   services {
     auth {
       host = localhost

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -60,11 +60,18 @@ mongodb {
   uri = "mongodb://localhost:27017/disa-registration-stubs"
 }
 
+host = "http://localhost:1203"
+
 microservice {
   services {
     auth {
       host = localhost
       port = 8500
+    }
+
+    disa-registration-frontend {
+      host = localhost
+      port = 1202
     }
   }
 }

--- a/test/controllers/GrsControllerSpec.scala
+++ b/test/controllers/GrsControllerSpec.scala
@@ -30,7 +30,7 @@ import scala.concurrent.Future
 class GrsControllerSpec extends BaseUnitSpec {
 
   private def journeyRetrievalRequest(journeyId: String) =
-    FakeRequest(GET, s"/journey/$journeyId")
+    FakeRequest(GET, s"/incorporated-entity-identification/api/journey/$journeyId")
 
   private def journeyRetrievalJson(result: Future[play.api.mvc.Result]): JsValue =
     contentAsJson(result)
@@ -73,15 +73,17 @@ class GrsControllerSpec extends BaseUnitSpec {
       }
     }
 
-    "return identifiers mismatch scenario" in {
+    "return 200 with CT enrolled success payload" in {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, journeyRetrievalRequest("grs-retrieval-identifiers-fail")).get
+        val result = route(app, journeyRetrievalRequest("grs-retrieval-success-ct-enrolled")).get
 
         status(result) mustBe OK
-        (journeyRetrievalJson(result) \ "identifiersMatch").as[Boolean] mustBe false
-        (journeyRetrievalJson(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTRATION_FAILED"
+        (journeyRetrievalJson(result) \ "identifiersMatch").as[Boolean] mustBe true
+        (journeyRetrievalJson(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTERED"
+        (journeyRetrievalJson(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "CT_ENROLLED"
+        (journeyRetrievalJson(result) \ "registration" \ "registeredBusinessPartnerId").as[String] mustBe "111111"
       }
     }
 
@@ -92,29 +94,11 @@ class GrsControllerSpec extends BaseUnitSpec {
         val result = route(app, journeyRetrievalRequest("grs-retrieval-bv-fail")).get
 
         status(result) mustBe OK
+        (journeyRetrievalJson(result) \ "identifiersMatch").as[Boolean] mustBe true
         (journeyRetrievalJson(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "FAIL"
-      }
-    }
-
-    "return BV not called (UNCHALLENGED)" in {
-      running(fakeApplication()) {
-        authorisedUser()
-
-        val result = route(app, journeyRetrievalRequest("grs-retrieval-bv-not-called")).get
-
-        status(result) mustBe OK
-        (journeyRetrievalJson(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "UNCHALLENGED"
-      }
-    }
-
-    "return CT enrolled scenario" in {
-      running(fakeApplication()) {
-        authorisedUser()
-
-        val result = route(app, journeyRetrievalRequest("grs-retrieval-bv-ct-enrolled")).get
-
-        status(result) mustBe OK
-        (journeyRetrievalJson(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "CT_ENROLLED"
+        (journeyRetrievalJson(result) \ "registration" \ "registrationStatus")
+          .as[String] mustBe "REGISTRATION_NOT_CALLED"
+        (journeyRetrievalJson(result) \ "registration" \ "registeredBusinessPartnerId").toOption mustBe None
       }
     }
 
@@ -125,30 +109,24 @@ class GrsControllerSpec extends BaseUnitSpec {
         val result = route(app, journeyRetrievalRequest("grs-retrieval-registration-failed")).get
 
         status(result) mustBe OK
+        (journeyRetrievalJson(result) \ "identifiersMatch").as[Boolean] mustBe true
+        (journeyRetrievalJson(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "PASS"
         (journeyRetrievalJson(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTRATION_FAILED"
+        (journeyRetrievalJson(result) \ "registration" \ "registeredBusinessPartnerId").toOption mustBe None
       }
     }
 
-    "return registration not called scenario" in {
+    "return absent UTR scenario" in {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, journeyRetrievalRequest("grs-retrieval-registration-not-called")).get
+        val result = route(app, journeyRetrievalRequest("grs-retrieval-absent-utr")).get
 
         status(result) mustBe OK
+        (journeyRetrievalJson(result) \ "identifiersMatch").as[Boolean] mustBe false
+        (journeyRetrievalJson(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "UNCHALLENGED"
         (journeyRetrievalJson(result) \ "registration" \ "registrationStatus")
           .as[String] mustBe "REGISTRATION_NOT_CALLED"
-      }
-    }
-
-    "return response without ctutr when ct-utr-absent" in {
-      running(fakeApplication()) {
-        authorisedUser()
-
-        val result = route(app, journeyRetrievalRequest("grs-retrieval-ct-utr-absent")).get
-
-        status(result) mustBe OK
-        (journeyRetrievalJson(result) \ "ctutr").toOption mustBe None
       }
     }
 
@@ -179,7 +157,9 @@ class GrsControllerSpec extends BaseUnitSpec {
         val result = route(app, journeyRetrievalRequest("something-random")).get
 
         status(result) mustBe OK
+        (journeyRetrievalJson(result) \ "identifiersMatch").as[Boolean] mustBe true
         (journeyRetrievalJson(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTERED"
+        (journeyRetrievalJson(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "PASS"
       }
     }
 
@@ -209,19 +189,19 @@ class GrsControllerSpec extends BaseUnitSpec {
 
         status(result) mustBe CREATED
         (journeyRetrievalJson(result) \ "journeyStartUrl").as[String] mustBe
-          "http://localhost:1202/incorporated-identity-callback?journeyId=grs-create-journey-success"
+          "/obligations/enrolment/isa/incorporated-identity-callback?journeyId=grs-create-journey-success"
       }
     }
 
     "return 201 with journeyStartUrl using GRS retrieval scenario credId" in {
       running(fakeApplication()) {
-        authorisedUser(Some("bv-fail"))
+        authorisedUser(Some("grs-retrieval-bv-fail"))
 
         val result = route(app, createLimitedCompanyJourneyRequest()).get
 
         status(result) mustBe CREATED
         (journeyRetrievalJson(result) \ "journeyStartUrl").as[String] mustBe
-          "http://localhost:1202/incorporated-identity-callback?journeyId=bv-fail"
+          "/obligations/enrolment/isa/incorporated-identity-callback?journeyId=grs-retrieval-bv-fail"
       }
     }
 

--- a/test/controllers/GrsControllerSpec.scala
+++ b/test/controllers/GrsControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.matchers.must.Matchers.mustBe
-import play.api.libs.json.JsValue
+import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import uk.gov.hmrc.auth.core.*
@@ -29,11 +29,33 @@ import scala.concurrent.Future
 
 class GrsControllerSpec extends BaseUnitSpec {
 
-  private def request(journeyId: String) =
+  private def journeyRetrievalRequest(journeyId: String) =
     FakeRequest(GET, s"/journey/$journeyId")
 
-  private def json(result: Future[play.api.mvc.Result]): JsValue =
+  private def journeyRetrievalJson(result: Future[play.api.mvc.Result]): JsValue =
     contentAsJson(result)
+
+  private val createLimitedCompanyJourneyUrl =
+    "/incorporated-entity-identification/api/limited-company-journey"
+
+  private val validCreateJourneyJson: JsObject = Json.obj(
+    "continueUrl"               -> "/testUrl",
+    "businessVerificationCheck" -> true,
+    "deskProServiceId"          -> "DeskProServiceId",
+    "signOutUrl"                -> "/testSignOutUrl",
+    "regime"                    -> "DISA",
+    "accessibilityUrl"          -> "/accessibility-statement/my-service"
+  )
+
+  private val invalidUrlsCreateJourneyJson: JsObject =
+    validCreateJourneyJson ++ Json.obj(
+      "continueUrl" -> "https://example.com/testUrl"
+    )
+
+  private def createLimitedCompanyJourneyRequest(json: JsValue = validCreateJourneyJson) =
+    FakeRequest(POST, createLimitedCompanyJourneyUrl)
+      .withHeaders(CONTENT_TYPE -> "application/json")
+      .withJsonBody(json)
 
   "GrsController.retrieveJourneyData" should {
 
@@ -41,13 +63,13 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, request("success")).get
+        val result = route(app, journeyRetrievalRequest("success")).get
 
         status(result) mustBe OK
-        (json(result) \ "identifiersMatch").as[Boolean] mustBe true
-        (json(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTERED"
-        (json(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "PASS"
-        (json(result) \ "ctutr").as[String] mustBe "1234567890"
+        (journeyRetrievalJson(result) \ "identifiersMatch").as[Boolean] mustBe true
+        (journeyRetrievalJson(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTERED"
+        (journeyRetrievalJson(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "PASS"
+        (journeyRetrievalJson(result) \ "ctutr").as[String] mustBe "1234567890"
       }
     }
 
@@ -55,11 +77,11 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, request("identifiers-fail")).get
+        val result = route(app, journeyRetrievalRequest("identifiers-fail")).get
 
         status(result) mustBe OK
-        (json(result) \ "identifiersMatch").as[Boolean] mustBe false
-        (json(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTRATION_FAILED"
+        (journeyRetrievalJson(result) \ "identifiersMatch").as[Boolean] mustBe false
+        (journeyRetrievalJson(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTRATION_FAILED"
       }
     }
 
@@ -67,10 +89,10 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, request("bv-fail")).get
+        val result = route(app, journeyRetrievalRequest("bv-fail")).get
 
         status(result) mustBe OK
-        (json(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "FAIL"
+        (journeyRetrievalJson(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "FAIL"
       }
     }
 
@@ -78,10 +100,10 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, request("bv-not-called")).get
+        val result = route(app, journeyRetrievalRequest("bv-not-called")).get
 
         status(result) mustBe OK
-        (json(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "UNCHALLENGED"
+        (journeyRetrievalJson(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "UNCHALLENGED"
       }
     }
 
@@ -89,10 +111,10 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, request("bv-ct-enrolled")).get
+        val result = route(app, journeyRetrievalRequest("bv-ct-enrolled")).get
 
         status(result) mustBe OK
-        (json(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "CT_ENROLLED"
+        (journeyRetrievalJson(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "CT_ENROLLED"
       }
     }
 
@@ -100,10 +122,10 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, request("registration-failed")).get
+        val result = route(app, journeyRetrievalRequest("registration-failed")).get
 
         status(result) mustBe OK
-        (json(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTRATION_FAILED"
+        (journeyRetrievalJson(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTRATION_FAILED"
       }
     }
 
@@ -111,10 +133,11 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, request("registration-not-called")).get
+        val result = route(app, journeyRetrievalRequest("registration-not-called")).get
 
         status(result) mustBe OK
-        (json(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTRATION_NOT_CALLED"
+        (journeyRetrievalJson(result) \ "registration" \ "registrationStatus")
+          .as[String] mustBe "REGISTRATION_NOT_CALLED"
       }
     }
 
@@ -122,10 +145,10 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, request("ct-utr-absent")).get
+        val result = route(app, journeyRetrievalRequest("ct-utr-absent")).get
 
         status(result) mustBe OK
-        (json(result) \ "ctutr").toOption mustBe None
+        (journeyRetrievalJson(result) \ "ctutr").toOption mustBe None
       }
     }
 
@@ -133,7 +156,7 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, request("grs-data-not-found")).get
+        val result = route(app, journeyRetrievalRequest("grs-data-not-found")).get
 
         status(result) mustBe NOT_FOUND
       }
@@ -143,10 +166,10 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, request("something-random")).get
+        val result = route(app, journeyRetrievalRequest("something-random")).get
 
         status(result) mustBe OK
-        (json(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTERED"
+        (journeyRetrievalJson(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTERED"
       }
     }
 
@@ -159,9 +182,134 @@ class GrsControllerSpec extends BaseUnitSpec {
           )(any(), any())
         ).thenReturn(Future.failed(InsufficientEnrolments()))
 
-        val result = route(app, request("success")).get
+        val result = route(app, journeyRetrievalRequest("success")).get
 
         status(result) mustBe UNAUTHORIZED
+      }
+    }
+  }
+
+  "GrsController.createLimitedCompanyJourney" should {
+
+    "return 201 with journeyStartUrl when credId indicates create journey success" in {
+      running(fakeApplication()) {
+        authorisedUser(Some("grs-create-journey-success"))
+
+        val result = route(app, createLimitedCompanyJourneyRequest()).get
+
+        status(result) mustBe CREATED
+        (journeyRetrievalJson(result) \ "journeyStartUrl").as[String] mustBe
+          "http://localhost:1202/incorporated-identity-callback?journeyId=grs-create-journey-success"
+      }
+    }
+
+    "return 201 with journeyStartUrl using GRS retrieval scenario credId" in {
+      running(fakeApplication()) {
+        authorisedUser(Some("bv-fail"))
+
+        val result = route(app, createLimitedCompanyJourneyRequest()).get
+
+        status(result) mustBe CREATED
+        (journeyRetrievalJson(result) \ "journeyStartUrl").as[String] mustBe
+          "http://localhost:1202/incorporated-identity-callback?journeyId=bv-fail"
+      }
+    }
+
+    "return 401 when credId indicates create journey unauthorised" in {
+      running(fakeApplication()) {
+        authorisedUser(Some("grs-create-journey-unauthorised"))
+
+        val result = route(app, createLimitedCompanyJourneyRequest()).get
+
+        status(result) mustBe UNAUTHORIZED
+      }
+    }
+
+    "return 500 when credId indicates create journey upstream error" in {
+      running(fakeApplication()) {
+        authorisedUser(Some("grs-create-journey-upstream-error"))
+
+        val result = route(app, createLimitedCompanyJourneyRequest()).get
+
+        status(result) mustBe INTERNAL_SERVER_ERROR
+      }
+    }
+
+    "return 400 when credId indicates invalid json stub scenario" in {
+      running(fakeApplication()) {
+        authorisedUser(Some("grs-create-journey-invalid-json"))
+
+        val result = route(app, createLimitedCompanyJourneyRequest()).get
+
+        status(result) mustBe BAD_REQUEST
+        (journeyRetrievalJson(result) \ "code").as[String] mustBe "INVALID_JSON"
+        (journeyRetrievalJson(result) \ "message").as[String] mustBe "Request body is invalid"
+      }
+    }
+
+    "return 400 when credId indicates invalid urls stub scenario" in {
+      running(fakeApplication()) {
+        authorisedUser(Some("grs-create-journey-invalid-urls"))
+
+        val result = route(app, createLimitedCompanyJourneyRequest()).get
+
+        status(result) mustBe BAD_REQUEST
+        contentAsString(result) should include("JourneyConfig contained non-relative urls")
+      }
+    }
+
+    "return 400 when request contains non-relative urls" in {
+      running(fakeApplication()) {
+        authorisedUser(Some("grs-create-journey-success"))
+
+        val result = route(app, createLimitedCompanyJourneyRequest(invalidUrlsCreateJourneyJson)).get
+
+        status(result) mustBe BAD_REQUEST
+        contentAsString(result) should include("JourneyConfig contained non-relative urls")
+      }
+    }
+
+    "return 400 when request json does not match the expected model" in {
+      running(fakeApplication()) {
+        authorisedUser(Some("grs-create-journey-success"))
+
+        val result = route(
+          app,
+          createLimitedCompanyJourneyRequest(Json.obj("continueUrl" -> "/testUrl"))
+        ).get
+
+        status(result) mustBe BAD_REQUEST
+      }
+    }
+
+    "return 401 when authorisation throws" in {
+      running(fakeApplication()) {
+        when(
+          mockAuthConnector.authorise(
+            any(),
+            any()
+          )(any(), any())
+        ).thenReturn(Future.failed(InsufficientEnrolments()))
+
+        val result = route(app, createLimitedCompanyJourneyRequest()).get
+
+        status(result) mustBe UNAUTHORIZED
+      }
+    }
+
+    "return 500 when credentials cannot be retrieved from auth" in {
+      running(fakeApplication()) {
+        when(
+          mockAuthConnector.authorise(
+            any(),
+            any()
+          )(any(), any())
+        ).thenReturn(Future.successful(None))
+
+        val result = route(app, createLimitedCompanyJourneyRequest()).get
+
+        status(result) mustBe INTERNAL_SERVER_ERROR
+        contentAsString(result) mustBe "Internal ID could not be retrieved from Auth"
       }
     }
   }

--- a/test/controllers/GrsControllerSpec.scala
+++ b/test/controllers/GrsControllerSpec.scala
@@ -63,7 +63,7 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, journeyRetrievalRequest("success")).get
+        val result = route(app, journeyRetrievalRequest("grs-retrieval-success")).get
 
         status(result) mustBe OK
         (journeyRetrievalJson(result) \ "identifiersMatch").as[Boolean] mustBe true
@@ -77,7 +77,7 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, journeyRetrievalRequest("identifiers-fail")).get
+        val result = route(app, journeyRetrievalRequest("grs-retrieval-identifiers-fail")).get
 
         status(result) mustBe OK
         (journeyRetrievalJson(result) \ "identifiersMatch").as[Boolean] mustBe false
@@ -89,7 +89,7 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, journeyRetrievalRequest("bv-fail")).get
+        val result = route(app, journeyRetrievalRequest("grs-retrieval-bv-fail")).get
 
         status(result) mustBe OK
         (journeyRetrievalJson(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "FAIL"
@@ -100,7 +100,7 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, journeyRetrievalRequest("bv-not-called")).get
+        val result = route(app, journeyRetrievalRequest("grs-retrieval-bv-not-called")).get
 
         status(result) mustBe OK
         (journeyRetrievalJson(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "UNCHALLENGED"
@@ -111,7 +111,7 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, journeyRetrievalRequest("bv-ct-enrolled")).get
+        val result = route(app, journeyRetrievalRequest("grs-retrieval-bv-ct-enrolled")).get
 
         status(result) mustBe OK
         (journeyRetrievalJson(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "CT_ENROLLED"
@@ -122,7 +122,7 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, journeyRetrievalRequest("registration-failed")).get
+        val result = route(app, journeyRetrievalRequest("grs-retrieval-registration-failed")).get
 
         status(result) mustBe OK
         (journeyRetrievalJson(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTRATION_FAILED"
@@ -133,7 +133,7 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, journeyRetrievalRequest("registration-not-called")).get
+        val result = route(app, journeyRetrievalRequest("grs-retrieval-registration-not-called")).get
 
         status(result) mustBe OK
         (journeyRetrievalJson(result) \ "registration" \ "registrationStatus")
@@ -145,7 +145,7 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, journeyRetrievalRequest("ct-utr-absent")).get
+        val result = route(app, journeyRetrievalRequest("grs-retrieval-ct-utr-absent")).get
 
         status(result) mustBe OK
         (journeyRetrievalJson(result) \ "ctutr").toOption mustBe None
@@ -156,9 +156,19 @@ class GrsControllerSpec extends BaseUnitSpec {
       running(fakeApplication()) {
         authorisedUser()
 
-        val result = route(app, journeyRetrievalRequest("grs-data-not-found")).get
+        val result = route(app, journeyRetrievalRequest("grs-retrieval-data-not-found")).get
 
         status(result) mustBe NOT_FOUND
+      }
+    }
+
+    "return 401 when journeyId indicates stubbed unauthorised scenario" in {
+      running(fakeApplication()) {
+        authorisedUser()
+
+        val result = route(app, journeyRetrievalRequest("grs-retrieval-unauthorised")).get
+
+        status(result) mustBe UNAUTHORIZED
       }
     }
 
@@ -182,7 +192,7 @@ class GrsControllerSpec extends BaseUnitSpec {
           )(any(), any())
         ).thenReturn(Future.failed(InsufficientEnrolments()))
 
-        val result = route(app, journeyRetrievalRequest("success")).get
+        val result = route(app, journeyRetrievalRequest("grs-retrieval-success")).get
 
         status(result) mustBe UNAUTHORIZED
       }

--- a/test/controllers/GrsControllerSpec.scala
+++ b/test/controllers/GrsControllerSpec.scala
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.matchers.must.Matchers.mustBe
+import play.api.libs.json.JsValue
+import play.api.test.FakeRequest
+import play.api.test.Helpers.*
+import uk.gov.hmrc.auth.core.*
+import utils.BaseUnitSpec
+
+import scala.concurrent.Future
+
+class GrsControllerSpec extends BaseUnitSpec {
+
+  private def request(journeyId: String) =
+    FakeRequest(GET, s"/journey/$journeyId")
+
+  private def json(result: Future[play.api.mvc.Result]): JsValue =
+    contentAsJson(result)
+
+  "GrsController.retrieveJourneyData" should {
+
+    "return 200 with success payload" in {
+      running(fakeApplication()) {
+        authorisedUser()
+
+        val result = route(app, request("success")).get
+
+        status(result) mustBe OK
+        (json(result) \ "identifiersMatch").as[Boolean] mustBe true
+        (json(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTERED"
+        (json(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "PASS"
+        (json(result) \ "ctutr").as[String] mustBe "1234567890"
+      }
+    }
+
+    "return identifiers mismatch scenario" in {
+      running(fakeApplication()) {
+        authorisedUser()
+
+        val result = route(app, request("identifiers-fail")).get
+
+        status(result) mustBe OK
+        (json(result) \ "identifiersMatch").as[Boolean] mustBe false
+        (json(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTRATION_FAILED"
+      }
+    }
+
+    "return BV fail scenario" in {
+      running(fakeApplication()) {
+        authorisedUser()
+
+        val result = route(app, request("bv-fail")).get
+
+        status(result) mustBe OK
+        (json(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "FAIL"
+      }
+    }
+
+    "return BV not called (UNCHALLENGED)" in {
+      running(fakeApplication()) {
+        authorisedUser()
+
+        val result = route(app, request("bv-not-called")).get
+
+        status(result) mustBe OK
+        (json(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "UNCHALLENGED"
+      }
+    }
+
+    "return CT enrolled scenario" in {
+      running(fakeApplication()) {
+        authorisedUser()
+
+        val result = route(app, request("bv-ct-enrolled")).get
+
+        status(result) mustBe OK
+        (json(result) \ "businessVerification" \ "verificationStatus").as[String] mustBe "CT_ENROLLED"
+      }
+    }
+
+    "return registration failed scenario" in {
+      running(fakeApplication()) {
+        authorisedUser()
+
+        val result = route(app, request("registration-failed")).get
+
+        status(result) mustBe OK
+        (json(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTRATION_FAILED"
+      }
+    }
+
+    "return registration not called scenario" in {
+      running(fakeApplication()) {
+        authorisedUser()
+
+        val result = route(app, request("registration-not-called")).get
+
+        status(result) mustBe OK
+        (json(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTRATION_NOT_CALLED"
+      }
+    }
+
+    "return response without ctutr when ct-utr-absent" in {
+      running(fakeApplication()) {
+        authorisedUser()
+
+        val result = route(app, request("ct-utr-absent")).get
+
+        status(result) mustBe OK
+        (json(result) \ "ctutr").toOption mustBe None
+      }
+    }
+
+    "return 404 when journey not found" in {
+      running(fakeApplication()) {
+        authorisedUser()
+
+        val result = route(app, request("grs-data-not-found")).get
+
+        status(result) mustBe NOT_FOUND
+      }
+    }
+
+    "default to success-like response for unknown journeyId" in {
+      running(fakeApplication()) {
+        authorisedUser()
+
+        val result = route(app, request("something-random")).get
+
+        status(result) mustBe OK
+        (json(result) \ "registration" \ "registrationStatus").as[String] mustBe "REGISTERED"
+      }
+    }
+
+    "return 401 when authorisation throws" in {
+      running(fakeApplication()) {
+        when(
+          mockAuthConnector.authorise(
+            any(),
+            any()
+          )(any(), any())
+        ).thenReturn(Future.failed(InsufficientEnrolments()))
+
+        val result = route(app, request("success")).get
+
+        status(result) mustBe UNAUTHORIZED
+      }
+    }
+  }
+}

--- a/test/utils/BaseUnitSpec.scala
+++ b/test/utils/BaseUnitSpec.scala
@@ -19,7 +19,6 @@ package utils
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.mockito.Mockito.when
-import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.*
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers

--- a/test/utils/BaseUnitSpec.scala
+++ b/test/utils/BaseUnitSpec.scala
@@ -16,20 +16,24 @@
 
 package utils
 
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
+import org.mockito.Mockito.when
+import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.*
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.{Application, inject}
+import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.DefaultAwaitTimeout
 import uk.gov.hmrc.auth.core.AuthConnector
+import play.api.{Application, inject}
 import uk.gov.hmrc.http.HeaderCarrier
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 abstract class BaseUnitSpec
     extends AnyWordSpec
@@ -52,4 +56,12 @@ abstract class BaseUnitSpec
   override def fakeApplication(): Application = GuiceApplicationBuilder()
     .overrides(inject.bind[AuthConnector].toInstance(mockAuthConnector))
     .build()
+
+  def authorisedUser(): OngoingStubbing[Future[Unit]] =
+    when(
+      mockAuthConnector.authorise[Unit](
+        any(),
+        any()
+      )(any(), any())
+    ).thenReturn(Future.unit)
 }

--- a/test/utils/BaseUnitSpec.scala
+++ b/test/utils/BaseUnitSpec.scala
@@ -29,8 +29,10 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.DefaultAwaitTimeout
+import play.api.{Application, inject}
 import uk.gov.hmrc.auth.core.AuthConnector
 import play.api.{Application, inject}
+import uk.gov.hmrc.auth.core.retrieve.Credentials
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -57,11 +59,13 @@ abstract class BaseUnitSpec
     .overrides(inject.bind[AuthConnector].toInstance(mockAuthConnector))
     .build()
 
-  def authorisedUser(): OngoingStubbing[Future[Unit]] =
+  def authorisedUser(credId: Option[String] = None): Unit =
     when(
-      mockAuthConnector.authorise[Unit](
+      mockAuthConnector.authorise(
         any(),
         any()
       )(any(), any())
-    ).thenReturn(Future.unit)
+    ).thenReturn(
+      credId.fold(Future.unit)(credId => Future.successful(Some(Credentials(credId, "GovernmentGateway"))))
+    )
 }


### PR DESCRIPTION
- This incorporates "passthrough" to the jourey data retrieval endpoint, by handing back the frontend's own callback url with the `credId` passed through as the journeyId in the URL.
- Need to add some stuff to app-config-base files for both the stub and fronted for this to work in any environment.
